### PR TITLE
fix: use run method and throw error used outside of context

### DIFF
--- a/src/AsyncHttpContext.ts
+++ b/src/AsyncHttpContext.ts
@@ -26,12 +26,16 @@ export default class AsyncHttpContext {
     return new Proxy(this, proxyHandler)
   }
 
-  public runSyncAndReturn (context, next) {
-    return this.$context.runSyncAndReturn(context, next)
+  public run (context, next) {
+    return this.$context.run(context, next)
   }
 
   public get context () {
-    return this.$context.getStore() || {}
+    const store = this.$context.getStore()
+    if (store === undefined) {
+      throw new Error('AsyncHttpContext cannot be used outside of a request context')
+    }
+    return store;
   }
 }
 

--- a/src/AsyncHttpContextMiddleware.ts
+++ b/src/AsyncHttpContextMiddleware.ts
@@ -5,6 +5,6 @@ export default class AsyncHttpContextMiddleware {
   }
 
   public async handle (ctx: HttpContextContract, next: () => Promise<void>) {
-    return this.$context.runSyncAndReturn(ctx, next)
+    return this.$context.run(ctx, next)
   }
 }


### PR DESCRIPTION
`runSyncAndReturn` was removed from Node.js in https://github.com/nodejs/node/pull/31950