### PR TITLE
feat: add public ctx, getStore and enterWith

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,24 @@
 declare module '@ioc:Adonis/Core/AsyncHttpContext' {
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
-  const AsyncHttpContext: HttpContextContract
+  interface IAsyncHttpContext {
+    /**
+     * Returns the current AdonisJS HTTP context or throws if there is none.
+     */
+    readonly ctx: HttpContextContract
+
+    /**
+     * Returns the current AdonisJS HTTP context or `undefined`.
+     */
+    getStore(): HttpContextContract | undefined
+
+    /**
+     * Transition into the context for the remainder of the current synchronous
+     * execution. This method can be used in tests to mock the AdonisJS context.
+     */
+    enterWith(context: Partial<HttpContextContract>): void
+  }
+
+  const AsyncHttpContext: HttpContextContract & IAsyncHttpContext
   export default AsyncHttpContext
 }

--- a/src/AsyncHttpContext.ts
+++ b/src/AsyncHttpContext.ts
@@ -16,11 +16,11 @@ const proxyHandler: ProxyHandler<AsyncHttpContext> = {
       return Reflect.get(target, name, receiver)
     }
 
-    return Reflect.get(target.context, name, receiver)
+    return Reflect.get(target.ctx, name, receiver)
   },
 
   set (target, name, value, receiver) {
-    return Reflect.set(target.context, name, value, receiver)
+    return Reflect.set(target.ctx, name, value, receiver)
   },
 }
 
@@ -33,11 +33,20 @@ export default class AsyncHttpContext {
     return new Proxy(this, proxyHandler)
   }
 
-  public run (context, next) {
+  // Internal
+  public $run (context, next) {
     return this.$context.run(context, next)
   }
 
-  public get context () {
+  public getStore() {
+    return this.$context.getStore()
+  }
+
+  public enterWith(store) {
+    return this.$context.enterWith(store)
+  }
+
+  public get ctx () {
     const store = this.$context.getStore()
     if (store === undefined) {
       throw new Error('AsyncHttpContext cannot be used outside of a request context')
@@ -45,4 +54,3 @@ export default class AsyncHttpContext {
     return store;
   }
 }
-

--- a/src/AsyncHttpContextMiddleware.ts
+++ b/src/AsyncHttpContextMiddleware.ts
@@ -5,6 +5,6 @@ export default class AsyncHttpContextMiddleware {
   }
 
   public async handle (ctx: HttpContextContract, next: () => Promise<void>) {
-    return this.$context.run(ctx, next)
+    return this.$context.$run(ctx, next)
   }
 }


### PR DESCRIPTION
- ctx to get access to the full AdonisJS context object
- getStore to use AsyncHttpContext in places where there may be no current request
- enterWith to mock the context in tests